### PR TITLE
Fix Warp Coordinates Ayothaya NPC (Pre-Renewal)

### DIFF
--- a/npc/cities/ayothaya.txt
+++ b/npc/cities/ayothaya.txt
@@ -86,10 +86,7 @@ ayothaya,152,68,1	script	Aibakthing#ayo2	843,{
 		mes "[Aibakthing]";
 		mes "You will be welcome to come back whenever you please. I hope that we will see each other again sometime soon. Thank you~";
 		close2;
-		if (checkre(0))
-			warp "alberta",235,45;
-		else
-			warp "alberta",238,22;
+		warp "alberta",235,45;
 		end;
 	}
 	mes "[Aibakthing]";


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2172aa23-0a4e-492c-851f-4997a74ef6d6)



The current warp for pre-renewal teleports the character to a non-walkable cell.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

Remove IF statement to use the same warp coordinate for PRE-RE and RE.

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

The current warp for pre-renewal teleports the character to a non-walkable cell. The incorrect coordinate will be removed, ensuring the same coordinate is used for both renewal and pre-renewal.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
